### PR TITLE
Publication workflow

### DIFF
--- a/components/Admin/RegisterUserModal.vue
+++ b/components/Admin/RegisterUserModal.vue
@@ -35,76 +35,69 @@
         {{ error }}
       </div>
 
-        <b-form-group
-          id="input-group-1"
-          label="Name:"
-          label-for="input-1"
-        >
-          <b-form-input
-            id="input-1"
-            v-model="form.name"
-            type="text"
-            placeholder="Enter name"
-            required
-          ></b-form-input>
-        </b-form-group>
+      <b-form-group
+        id="input-group-1"
+        label="Name:"
+        label-for="input-1"
+      >
+        <b-form-input
+          id="input-1"
+          v-model="form.name"
+          type="text"
+          placeholder="Enter name"
+          required
+        ></b-form-input>
+      </b-form-group>
 
-        <b-form-group
-          id="input-group-2"
-          label="Email address:"
-          label-for="input-2"
-        >
-          <b-form-input
-            id="input-2"
-            v-model="form.email"
-            type="email"
-            placeholder="Enter email"
-            required
-          ></b-form-input>
-        </b-form-group>
+      <b-form-group
+        id="input-group-2"
+        label="Email address:"
+        label-for="input-2"
+      >
+        <b-form-input
+          id="input-2"
+          v-model="form.email"
+          type="email"
+          placeholder="Enter email"
+          required
+        ></b-form-input>
+      </b-form-group>
 
-        <b-form-group 
-          id="input-group-3" 
-          label="Password:" 
-          label-for="input-3"
-        >
-          <b-form-input
-            id="input-3"
-            v-model="form.password"
-            placeholder="Enter password"
-            type="password"
-            required
-          ></b-form-input>
-        </b-form-group>
-        <b-form-group 
-          id="input-group-4" 
-          label="Password:" 
-          label-for="input-4"
-        >
-          <b-form-input
-            id="input-4"
-            v-model="form.password_confirmation"
-            placeholder="Confirm password"
-            type="password"
-            required
-          ></b-form-input>
-        </b-form-group>
-
-        <!-- <template #modal-footer="{ cancel }">
-          <b-button @click="cancel()">
-            Cancel
-          </b-button>
-          <b-button variant="primary" @click="register()">
-            OK
-          </b-button>
-        </template> -->
+      <b-form-group 
+        id="input-group-3" 
+        label="Password:" 
+        label-for="input-3"
+      >
+        <b-form-input
+          id="input-3"
+          v-model="form.password"
+          placeholder="Enter password"
+          type="password"
+          required
+        ></b-form-input>
+      </b-form-group>
+      <b-form-group 
+        id="input-group-4" 
+        label="Password:" 
+        label-for="input-4"
+      >
+        <b-form-input
+          id="input-4"
+          v-model="form.password_confirmation"
+          placeholder="Confirm password"
+          type="password"
+          required
+        ></b-form-input>
+      </b-form-group>
     </b-modal>
   </div>
 </template>
 
 <script>
-import registerMutation from '@/graphql/mutations/registerMutation'
-import linkUserToAgentMutation from '@/graphql/mutations/linkUserToAgentMutation'
+import RegisterMutation from '@/graphql/mutations/RegisterMutation'
+import LinkUserToAgentMutation from '@/graphql/mutations/LinkUserToAgentMutation'
+import CreateUserPreferencesMutation from '@/graphql/mutations/CreateUserPreferencesMutation'
+
 import { LinkToUserInput } from '@/models/AgentModel'
 
 export default {
@@ -123,7 +116,6 @@ export default {
   },
   methods: {
     onRegisterUserClicked() {
-      this.message = null
       this.form = {}
       this.$bvModal.show('register-user-modal')
     },
@@ -131,13 +123,14 @@ export default {
       bvModalEvent.preventDefault()
       console.log(JSON.stringify({input: this.form}, null, 2))
       this.$apollo.mutate({
-        mutation: registerMutation,
+        mutation: RegisterMutation,
         variables: {
           input: this.form
         }
       }).then(({ data }) => {
         this.linkUserToAgent(data.register.tokens.user)
         $nuxt.$emit('user-registered', 'Registration successful')
+        this.createUserPreferences(data.register.token.user)
         this.$bvModal.hide('register-user-modal')
       }).catch((error) => {
         this.error = error
@@ -146,12 +139,26 @@ export default {
     linkUserToAgent(user) {
       const input = new LinkToUserInput(user)
       this.$apollo.mutate({
-        mutation: linkUserToAgentMutation,
+        mutation: LinkUserToAgentMutation,
         variables: {
           input: input,
         },
       })
-    }
+    },
+    createUserPreferences(user) {
+      const input = {
+        user: {
+          connect: user.id
+        },
+        defaultPublicationStatus: 'PUBLISHED',
+      }
+      this.$apollo.mutate({
+        mutation: CreateUserPreferencesMutation,
+        variables: {
+          input: input,
+        },
+      })
+    },
   },
 }
 </script>

--- a/components/Admin/UserPreferencesModal.vue
+++ b/components/Admin/UserPreferencesModal.vue
@@ -1,0 +1,107 @@
+<!--
+ Copyright 2022 Royal Botanic Gardens Board
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+     http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<template>
+  <div>
+    <a
+      href=""
+      @click.prevent="onUserPreferencesClicked"
+    >
+      Preferences
+    </a>
+    <b-modal 
+      id="user-preferences-modal" 
+      title="User preferences"
+      @ok="updatePreferences"
+    >
+      <div 
+        v-if="error"
+        class="alert alert-danger text-center"
+        role="alert"
+      >
+        {{ error }}
+      </div>
+
+      <b-form-group
+        id="input-group-1"
+        label="Default publication status:"
+        label-for="input-1"
+      >
+        <b-form-select 
+          v-model="defaultPublicationStatus" 
+          :options="options"
+        ></b-form-select>
+      </b-form-group>
+    </b-modal>
+  </div>  
+</template>
+
+<script>
+import UpdateUserPreferencesMutation 
+    from '@/graphql/mutations/UpdateUserPreferencesMutation'
+
+export default {
+  name: "UserPreferencesModal",
+  data() {
+    return {
+      defaultPublicationStatus: '',
+      options: [
+        { value: 'PUBLISHED', text: 'published'},
+        { value: 'DRAFT', text: 'draft'},
+      ],
+      error: null,
+    }
+  },
+  computed: {
+    user() {
+      return this.$store.getters.user
+    },
+  },
+  methods: {
+    onUserPreferencesClicked() {
+      this.defaultPublicationStatus = this.user.preferences.defaultPublicationStatus
+      this.$bvModal.show('user-preferences-modal')
+    },
+    updatePreferences(bvModalEvent) {
+      bvModalEvent.preventDefault()
+      const input = {
+        user: {
+          connect: this.user.id
+        },
+        defaultPublicationStatus: this.defaultPublicationStatus
+      }
+      console.log(input)
+      this.$apollo.mutate({
+        mutation: UpdateUserPreferencesMutation,
+        variables: {
+          input: input
+        }
+      }).then(({data}) => {
+        console.log(data)
+        this.$store.dispatch('updateUserPreferences', {
+          defaultPublicationStatus: this.defaultPublicationStatus
+        })
+        $nuxt.$emit('user-preferences-updated', 
+            `Default publication status updated to 
+            '${this.defaultPublicationStatus}'`)
+        this.$bvModal.hide('user-preferences-modal')
+      }).catch(error => {
+        $nuxt.$emit('user-preferences-update-fail', error)
+      })
+    },
+  }
+}
+</script>

--- a/components/App/TheLoginBar.vue
+++ b/components/App/TheLoginBar.vue
@@ -28,21 +28,13 @@
 
 <script>
 import gql from "graphql-tag"
+import AuthenticatedUserQuery from '@/graphql/queries/AuthenticatedUserQuery'
 
 export default {
   name: 'TheLoginBar',
   apollo: {
     user: {
-      query: gql`query {
-        user:authenticatedUser {
-          id
-          name
-          email
-          agent {
-            id
-          }
-        }  
-      }`,
+      query: AuthenticatedUserQuery,
       skip: true,
       result({ data, loading }) {
         if (!loading) {

--- a/components/Forms/TaxonConceptForm.vue
+++ b/components/Forms/TaxonConceptForm.vue
@@ -38,79 +38,13 @@ import {
   CreateTaxonConceptInput 
 } from "@/models/TaxonConceptModel"
 import { formMethodsMixin } from "@/mixins/formMixins"
-import gql from "graphql-tag"
+import UpdateTaxonConceptMutation 
+    from '@/graphql/mutations/UpdateTaxonConceptMutation'
+import CreateTaxonConceptMutation 
+    from '@/graphql/mutations/CreateTaxonConceptMutation'
 
-const TaxonConceptFormGenerator = () => import('@/components/Forms/TaxonConceptFormGenerator')
-
-const UpdateTaxonConceptMutation = gql`mutation UpdateTaxonConceptMutation($input: UpdateTaxonConceptInput!) {
-  updateTaxonConcept(input: $input) {
-    id
-    taxonName {
-      id
-      fullName
-      authorship
-    }
-    taxonRank
-    taxonomicStatus
-    occurrenceStatus
-    endemic
-    establishmentMeans
-    hasIntroducedOccurrences
-    degreeOfEstablishment
-    parent {
-      id
-      taxonName {
-        id
-        fullName
-        authorship
-      }
-    }
-    acceptedConcept {
-      id
-      taxonName {
-        id
-        fullName
-        authorship
-      }
-    }
-    remarks
-  }
-}`
-
-const CreateTaxonConceptMutation = gql`mutation CreateTaxonConceptMutation($input: CreateTaxonConceptInput!) {
-  createTaxonConcept(input: $input) {
-    id
-    taxonName {
-      id
-      fullName
-      authorship
-    }
-    taxonRank
-    taxonomicStatus
-    occurrenceStatus
-    endemic
-    establishmentMeans
-    hasIntroducedOccurrences
-    degreeOfEstablishment
-    parent {
-      id
-      taxonName {
-        id
-        fullName
-        authorship
-      }
-    }
-    acceptedConcept {
-      id
-      taxonName {
-        id
-        fullName
-        authorship
-      }
-    }
-    remarks
-  }
-}`
+const TaxonConceptFormGenerator = () => 
+  import('@/components/Forms/TaxonConceptFormGenerator')
 
 export default {
   name: "TaxonConceptForm",

--- a/components/Forms/TaxonConceptForm.vue
+++ b/components/Forms/TaxonConceptForm.vue
@@ -124,6 +124,12 @@ export default {
       this.schema[index].buttons = ['update']
     }
   },
+  mounted() {
+    if (this.id === 'taxon-concept-create') {
+      this.formData.publicationStatus = 
+          this.$store.getters.user.preferences.defaultPublicationStatus
+    }
+  },
   methods: {
     handleTaxonomicStatus(value) {
       if (value === 'ACCEPTED') {

--- a/components/Taxon/TaxonBreadcrumbs.vue
+++ b/components/Taxon/TaxonBreadcrumbs.vue
@@ -2,7 +2,7 @@
   <b-breadcrumb>
     <!-- higherClassification -->
     <Crumb
-      v-for="item in concept.higherClassification.slice(1)"
+      v-for="item in concept.higherClassification"
       :key="item.id"
       :taxonConcept="item"
     />

--- a/config/taxonConceptFormSchema.js
+++ b/config/taxonConceptFormSchema.js
@@ -192,6 +192,15 @@ export default [
     name: "remarks",
     label: "Comments",
     rows: 4,
-  }
+  },
+  {
+    fieldType: "SelectList",
+    name: "publicationStatus",
+    label: "Publication status",
+    options: [
+      { value: "DRAFT", label: "draft" },
+      { value: "PUBLISHED", label: "published" },
+    ],
+  },
 
 ]

--- a/constants/facet-fields.js
+++ b/constants/facet-fields.js
@@ -126,7 +126,13 @@ export const FILTER_FIELDS = [
     "name": "media",
     "label": "Media",
     "group": "miscellaneous"
-  }
+  },
+  {
+    "name": "publication_status",
+    "label": "Publication status",
+    "group": "miscellaneous"
+  },
+
 ]
 
 export const DEFAULT_FACET_FIELDS = [

--- a/graphql/mutations/CreateTaxonConceptMutation.gql
+++ b/graphql/mutations/CreateTaxonConceptMutation.gql
@@ -1,0 +1,35 @@
+mutation CreateTaxonConceptMutation($input: CreateTaxonConceptInput!) {
+  createTaxonConcept(input: $input) {
+    id
+    taxonName {
+      id
+      fullName
+      authorship
+    }
+    taxonRank
+    taxonomicStatus
+    occurrenceStatus
+    endemic
+    establishmentMeans
+    hasIntroducedOccurrences
+    degreeOfEstablishment
+    parent {
+      id
+      taxonName {
+        id
+        fullName
+        authorship
+      }
+    }
+    acceptedConcept {
+      id
+      taxonName {
+        id
+        fullName
+        authorship
+      }
+    }
+    remarks
+    publicationStatus
+  }
+}

--- a/graphql/mutations/CreateUserPreferencesMutation.gql
+++ b/graphql/mutations/CreateUserPreferencesMutation.gql
@@ -1,0 +1,9 @@
+mutation CreateUserPreferencesMutation($input: CreateUserPreferencesInput!) {
+  createUserPreferences(input: $input) {
+    user {
+      id
+      email
+    }
+    defaultPublicationStatus
+  }
+}

--- a/graphql/mutations/LinkUserToAgentMutation.gql
+++ b/graphql/mutations/LinkUserToAgentMutation.gql
@@ -1,4 +1,4 @@
-mutation linkUserToAgentMutation ($input: LinkUserInput!) {
+mutation LinkUserToAgentMutation ($input: LinkUserInput!) {
   linkUserToAgent(input: $input) {
     id
     name

--- a/graphql/mutations/LoginMutation.gql
+++ b/graphql/mutations/LoginMutation.gql
@@ -1,0 +1,22 @@
+mutation LoginMutation ($username: String!, $password: String!) {
+  login(input: {
+    username: $username,
+    password: $password
+  }) {
+    access_token
+    refresh_token
+    expires_in
+    token_type
+    user {
+      id
+      email
+      name
+      agent {
+        id
+      }
+      preferences {
+        defaultPublicationStatus
+      }
+    }
+  }
+}

--- a/graphql/mutations/RegisterMutation.gql
+++ b/graphql/mutations/RegisterMutation.gql
@@ -1,4 +1,4 @@
-mutation registerMutation ($input: RegisterInput!) {
+mutation RegisterMutation ($input: RegisterInput!) {
   register(input: $input) {
     status
     tokens {

--- a/graphql/mutations/UpdateTaxonConceptMutation.gql
+++ b/graphql/mutations/UpdateTaxonConceptMutation.gql
@@ -1,0 +1,35 @@
+mutation UpdateTaxonConceptMutation($input: UpdateTaxonConceptInput!) {
+  updateTaxonConcept(input: $input) {
+    id
+    taxonName {
+      id
+      fullName
+      authorship
+    }
+    taxonRank
+    taxonomicStatus
+    occurrenceStatus
+    endemic
+    establishmentMeans
+    hasIntroducedOccurrences
+    degreeOfEstablishment
+    parent {
+      id
+      taxonName {
+        id
+        fullName
+        authorship
+      }
+    }
+    acceptedConcept {
+      id
+      taxonName {
+        id
+        fullName
+        authorship
+      }
+    }
+    remarks
+    publicationStatus
+  }
+}

--- a/graphql/mutations/UpdateUserPreferencesMutation.gql
+++ b/graphql/mutations/UpdateUserPreferencesMutation.gql
@@ -1,0 +1,9 @@
+mutation UpdateUserPreferencesMutation($input: UpdateUserPreferencesInput!) {
+  updateUserPreferences(input: $input) {
+    user {
+      id
+      email
+    }
+    defaultPublicationStatus
+  }
+}

--- a/graphql/queries/AuthenticatedUserQuery.gql
+++ b/graphql/queries/AuthenticatedUserQuery.gql
@@ -1,0 +1,13 @@
+query {
+  user:authenticatedUser {
+    id
+    name
+    email
+    agent {
+      id
+    }
+    preferences {
+      defaultPublicationStatus
+    }
+  }  
+}

--- a/graphql/queries/TaxonEditFormQuery.gql
+++ b/graphql/queries/TaxonEditFormQuery.gql
@@ -1,0 +1,72 @@
+query TaxonEditFormQuery($id: ID!) {
+  taxonConcept(id: $id) {
+    id
+    publicationStatus
+    taxonName {
+      id
+      fullName
+      authorship
+    }
+    taxonRank
+    taxonomicStatus
+    occurrenceStatus
+    endemic
+    establishmentMeans
+    hasIntroducedOccurrences
+    degreeOfEstablishment
+    taxonTreeDefItem {
+      id
+      name
+      rankId
+    }
+    parent {
+      id
+      taxonName {
+        id
+        fullName
+        authorship
+      }
+    }
+    acceptedConcept {
+      id
+      taxonName {
+        id
+        fullName
+        authorship
+      }
+    }
+    remarks
+    changes {
+      id
+      to {
+        id
+        taxonName {
+          id
+          fullName
+          authorship
+        }
+      }
+      changeType
+      changeSource {
+        quickRef
+      }
+      createdBy {
+        name
+      }
+      createdAt
+    }
+    vernacularNames {
+      id
+      name
+      isPreferred
+      nameUsage
+    },
+    references {
+      id
+      reference {
+        id
+        referenceStringHtml
+      }
+    }
+  }
+}

--- a/graphql/queries/taxonConceptQuery.gql
+++ b/graphql/queries/taxonConceptQuery.gql
@@ -27,6 +27,7 @@ query taxonConceptQuery($id: ID!) {
       quickRef
       referenceStringHtml
     }
+    publicationStatus
     acceptedConcept {
       ...taxonConceptFields
     }

--- a/models/TaxonConceptModel.js
+++ b/models/TaxonConceptModel.js
@@ -26,7 +26,8 @@ export class TaxonConcept {
     this.establishmentMeans = data.establishmentMeans
     this.hasIntroducedOccurrences = data.hasIntroducedOccurrences
     this.degreeOfEstablishment = data.degreeOfEstablishment
-    this.remarks = this.remarks
+    this.remarks = data.remarks
+    this.publicationStatus = data.publicationStatus
 
     this.taxonName = new TaxonName(data.taxonName || {})
     this.accordingTo = data.accordingTo ? new Reference(data.accordingTo) : null
@@ -45,7 +46,8 @@ export class UpdateTaxonConceptInput {
     this.establishmentMeans = data.establishmentMeans
     this.hasIntroducedOccurrences = data.hasIntroducedOccurrences
     this.degreeOfEstablishment = data.degreeOfEstablishment
-    this.remarks = this.remarks
+    this.remarks = data.remarks
+    this.publicationStatus = data.publicationStatus
 
     this.taxonName = {
       connect: data.taxonName.id
@@ -79,7 +81,8 @@ export class CreateTaxonConceptInput {
     this.establishmentMeans = data.establishmentMeans
     this.hasIntroducedOccurrences = data.hasIntroducedOccurrences
     this.degreeOfEstablishment = data.degreeOfEstablishment
-    this.remarks = this.remarks
+    this.remarks = data.remarks
+    this.publicationStatus = data.publicationStatus
 
     this.taxonName = {
       connect: data.taxonName.id

--- a/pages/flora/taxon/edit.vue
+++ b/pages/flora/taxon/edit.vue
@@ -43,82 +43,13 @@
 </router>
 
 <script>
+import gql from "graphql-tag"
+import TaxonEditFormQuery from '@/graphql/queries/TaxonEditFormQuery'
+
 const TaxonEditMenu = () => import('@/components/Taxon/TaxonEditMenu')
 const TaxonName = () => import('@/components/Taxon/TaxonName')
 const TaxonTabsEdit = () => import('@/components/Taxon/TaxonTabsEdit.vue')
 
-import gql from "graphql-tag"
-const taxonEditFormQuery = gql`query taxonEditFormQuery($id: ID!) {
-  taxonConcept(id: $id) {
-    id
-    taxonName {
-      id
-      fullName
-      authorship
-    }
-    taxonRank
-    taxonomicStatus
-    occurrenceStatus
-    endemic
-    establishmentMeans
-    hasIntroducedOccurrences
-    degreeOfEstablishment
-    taxonTreeDefItem {
-      id
-      name
-      rankId
-    }
-    parent {
-      id
-      taxonName {
-        id
-        fullName
-        authorship
-      }
-    }
-    acceptedConcept {
-      id
-      taxonName {
-        id
-        fullName
-        authorship
-      }
-    }
-    remarks
-    changes {
-      id
-      to {
-        id
-        taxonName {
-          id
-          fullName
-          authorship
-        }
-      }
-      changeType
-      changeSource {
-        quickRef
-      }
-      createdBy {
-        name
-      }
-      createdAt
-    }
-    vernacularNames {
-      id
-      name
-      isPreferred
-      nameUsage
-    },
-    references {
-      id
-      reference {
-        id
-        referenceStringHtml
-      }
-    }
-  }
-}`
 
 const updateSolrIndexMutation = gql`mutation UpdateSolrIndexMutation($id: ID!) {
 	updateSolrIndex(id: $id) {
@@ -140,7 +71,7 @@ export default {
   },
   apollo: {
     taxonConcept: {
-      query: taxonEditFormQuery,
+      query: TaxonEditFormQuery,
       result({ data, loading }) {
         if (!loading) {
           $nuxt.$emit('progress-bar-stop')

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -67,7 +67,7 @@
 </template>
 
 <script>
-import gql from "graphql-tag"
+import LoginMutation from '@/graphql/mutations/LoginMutation'
 
 export default {
   name: 'Login',
@@ -84,25 +84,7 @@ export default {
     login() {
       this.$apollo.mutate({
         // Query
-        mutation: gql`mutation LoginMutation ($username: String!, $password: String!) {
-          login(input: {
-            username: $username,
-            password: $password
-          }) {
-            access_token
-            refresh_token
-            expires_in
-            token_type
-            user {
-              id
-              email
-              name
-              agent {
-                id
-              }
-            }
-          }
-        }`,
+        mutation: LoginMutation,
         variables: {
           username: this.form.username,
           password: this.form.password,

--- a/pages/user.vue
+++ b/pages/user.vue
@@ -58,10 +58,9 @@
               </b-form-group>
             </div>
 
-            <p class="text-right user-page-links">
-              <ChangePasswordModal />&emsp;
-              <RegisterUserModal />
-            </p>
+            <UserPreferencesModal />
+            <ChangePasswordModal />
+            <RegisterUserModal />
           </b-card-body>
         </b-card>
       </b-col>
@@ -70,12 +69,14 @@
 </template>
 
 <script>
+const UserPreferencesModal = () => import('@/components/Admin/UserPreferencesModal')
 const ChangePasswordModal = () => import('@/components/Admin/ChangePasswordModal')
 const RegisterUserModal = () => import('@/components/Admin/RegisterUserModal')
 
 export default {
   name: 'User',
   components: {
+    UserPreferencesModal,
     ChangePasswordModal,
     RegisterUserModal,
   },
@@ -113,6 +114,19 @@ export default {
       this.classes['alert-danger'] = true
       this.message = error
     })
+
+    this.$nuxt.$on('user-preferences-updated', message => {
+      this.classes['alert-success'] = true
+      this.classes['alert-danger'] = false
+      this.message = message
+    })
+
+    this.$nuxt.$on('user-registration-fail', error => {
+      this.classes['alert-success'] = false
+      this.classes['alert-danger'] = true
+      this.message = error
+    })
+
   }
 }
 </script>

--- a/store/index.js
+++ b/store/index.js
@@ -7,8 +7,12 @@ export const state = () => ({
 export const getters = {
   isLoggedIn(state) {
     return state.token !== null
+  },
+  user(state) {
+    return state.user
   }
 }
+
   
 export const mutations = {
   storeToken (state, token) {
@@ -25,6 +29,9 @@ export const mutations = {
   },
   storeSearchParams (state, params) {
     state.lastSearch = params
+  },
+  setUserPreferences(state, preferences) {
+    state.user.preferences = preferences
   }
 }
   
@@ -41,6 +48,9 @@ export const actions = {
   },
   storeSearchParams (context, params) {
     context.commit('storeSearchParams', params)
-  }
+  },
+  updateUserPreferences (context, preferences) {
+    context.commit('setUserPreferences', preferences)
+  },
 }
   


### PR DESCRIPTION
This will add some publication workflow to VicFlora. We've got two publications statuses, 'published' and 'draft'. Draft Taxon Concept records are only visible to logged-in users, i.e. VicFlora editors. This is all done in the API. In the client we need to set the publication status field in the form for new taxon concepts according to the user's preference.

- create user preferences when user is registered
- store user preferences when user logs in
- allow user to update preferences on user page
- set publication status on form for new taxa
- add publication status filter to Search
- add kingdom to taxon page braed crumbs