### PR TITLE
replace pagination on search page

### DIFF
--- a/components/Search/SearchResult.vue
+++ b/components/Search/SearchResult.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="vf-search-result col col-lg-8">
 
-    <SearchResultHeader :data="data" @pageChanged="onPageChange" />
+    <SearchResultHeader :data="data"/>
 
     <SearchResultItem 
       v-for="item in data.search.docs"
       :key="item.id"
       :item="item"
     />
-    <SearchResultFooter :data="data" @pageChanged="onPageChange" />
+    <SearchResultFooter :data="data"/>
   </div>
 </template>
 
@@ -46,11 +46,5 @@ export default {
         && this.$route.query.page !== undefined 
         ? parseInt(this.$route.query.page) : 1
   },
-  methods: {
-    onPageChange: function(pageNum) {
-      this.activePage = pageNum
-      this.$emit("pageChanged", pageNum)
-    }
-  }
 }
 </script>

--- a/components/Search/SearchResultFooter.vue
+++ b/components/Search/SearchResultFooter.vue
@@ -7,11 +7,7 @@
     />
 
     <BCol align-self="baseline">
-      <SearchResultNav
-          :activePage="activePage"
-          :lastPage="data.search.meta.pagination.lastPage"
-          @page-change="onPageChange"
-      />
+      <SearchResultNav :pagination="data.search.meta.pagination"/>
     </BCol>
 
     <BCol 
@@ -38,6 +34,6 @@ export default {
       type: Object,
       required: true
     }
-  }
+  },
 }
 </script>

--- a/components/Search/SearchResultHeader.vue
+++ b/components/Search/SearchResultHeader.vue
@@ -9,12 +9,7 @@
     </BCol>
 
     <BCol align-self="baseline">
-      <SearchResultNav
-          :activePage="activePage"
-          :lastPage="data.search.meta.pagination.lastPage"
-          @click.prevent
-          @pageChanged="onPageChange"
-      />
+      <SearchResultNav :pagination="data.search.meta.pagination"/>
     </BCol>
     
     <BCol cols="3" 
@@ -47,11 +42,5 @@ export default {
       required: true
     }
   },
-  methods: {
-    onPageChange(pageNum) {
-      this.activePage = pageNum
-      this.$emit("pageChanged", pageNum)
-    }
-  }
 }
 </script>

--- a/components/Search/SearchResultNav.vue
+++ b/components/Search/SearchResultNav.vue
@@ -1,12 +1,9 @@
 <template>
   <div class="mt-0 search-result-nav" style="display:inline-block">
-    <BPaginationNav
-      :value="currentPage"
-      :no-page-detect="true"
-      :number-of-pages="numberOfPages"
-      :link-gen="linkGen"
-      :use-router="false"
-      style="align-items:center;"
+    <BPagination
+      v-model="pagination.currentPage"
+      :total-rows="pagination.total"
+      per-page="50"
       size="sm"
       first-number
       last-number
@@ -20,16 +17,11 @@ import { searchMixin } from "@/mixins/searchMixins"
 
 export default {
   name: "SearchResultNav",
-  mixins: [searchMixin],
   props: {
-    activePage: {
-      type: Number,
-      default: 1
+    pagination: {
+      type: Object,
+      required: true,
     },
-    lastPage: {
-      type: Number,
-      required: true
-    }
   },
   data: function() {
     return {
@@ -42,47 +34,26 @@ export default {
     }
   },
   watch: {
-    q: {
+    '$route': {
+      deep: true,
       immediate: true,
-      handler: function() {
-        if ("page" in this.$route.query && this.$route.query.page !== undefined) {
-          this.currentPage = this.$route.query.page
+      handler() {
+        if (this.$route.query.page) {
+          this.pagination.currentPage = this.$route.query.page
         }
-      }
-    },
-    fq: {
-      immediate: true,
-      handler: function() {
-        if ("page" in this.$route.query && this.$route.query.page !== undefined) {
-          this.currentPage = this.$route.query.page
-        }
-      }
-    },
-    activePage: {
-      immediate: true,
-      handler: function(newVal) {
-        this.currentPage = newVal
       }
     }
   },
-  mounted: function() {
-    if ("page" in this.$route.query && this.$route.query.page !== undefined) {
-      this.currentPage = this.$route.query.page
-    }
-  },
+  mounted: function() {},
   methods: {
-    linkGen: function(pageNum) {
-      return {
-        path: this.$route.path,
+    onChange: function(pageNum) {
+      this.$router.push({
+        name: this.$route.name,
         query: {
           ...this.$route.query,
-          page: pageNum
-        }
-      }
-    },
-    onChange: function(pageNum) {
-      this.currentPage = pageNum
-      this.$emit("pageChanged", pageNum)
+          page: pageNum,
+        },
+      })
     }
   }
 }

--- a/pages/flora/checklist/index.vue
+++ b/pages/flora/checklist/index.vue
@@ -46,10 +46,7 @@
         </BCol>
 
         <client-only>
-          <SearchResult
-            :data="data"
-            @pageChanged="onPageChange"
-          />
+          <SearchResult :data="data"/>
         </client-only>
 
       </BRow>
@@ -189,6 +186,20 @@ export default {
         $nuxt.$emit('selected-area-set', this.selectedArea)
       },
       deep: true,
+    },
+    '$route': {
+      deep: true,
+      immediate: true,
+      handler() {
+        this.input = {
+          q: this.$route.query.q ? this.$route.query.q : "*",
+          rows: 50,
+          fq: this.$route.query.fq ? this.$route.query.fq : [],
+          page: this.$route.query.page ? this.$route.query.page : 1,
+          facetLimit: 20,
+          facetField: [],
+        }
+      }
     },
     input: {
       deep: true,

--- a/pages/flora/search/index.vue
+++ b/pages/flora/search/index.vue
@@ -33,7 +33,6 @@
       <client-only>
         <SearchResult
           :data="data"
-          @pageChanged="onPageChange"
         />
       </client-only>
 
@@ -95,6 +94,20 @@ export default {
     }
   },
   watch: {
+    '$route': {
+      deep: true,
+      immediate: true,
+      handler() {
+        this.input = {
+          q: this.$route.query.q ? this.$route.query.q : "*",
+          rows: 50,
+          fq: this.$route.query.fq ? this.$route.query.fq : [],
+          page: this.$route.query.page ? this.$route.query.page : 1,
+          facetLimit: 20,
+          facetField: [],
+        }
+      }
+    },
     input: {
       deep: true,
       handler: function() {
@@ -108,7 +121,6 @@ export default {
     },
   },
   created() {
-
     this.$apollo.queries.search.setVariables({
       input: {
         ...this.input,
@@ -136,14 +148,6 @@ export default {
     this.input.page = "page" in this.$route.query
         && this.$route.query.page !== undefined
         ? parseInt(this.$route.query.page) : 1
-  },
-  methods: {
-    onPageChange: function(pageNum) {
-      this.input = {
-        ...this.input,
-        page: parseInt(pageNum)
-      }
-    }
   },
 }
 </script>


### PR DESCRIPTION
Pagination on Search and Checklist pages showed some very funky behaviour, especially in Firefox. Also, the bottom pagination bar was not working at all.

Solution was to use the Bootstrap Vue <b-pagination/> component, rather than the <b-pagination-nav/> component that has been used before. Also, instead of emitting the page change three parents up, we now do a router push and have a watcher on the route on the Search and Checklist pages. 