### PR TITLE
More-editor-fixes

### DIFF
--- a/components/Forms/NewTaxonConceptForm.vue
+++ b/components/Forms/NewTaxonConceptForm.vue
@@ -197,6 +197,7 @@ export default {
       }).then(({ data }) => {
         console.log(JSON.stringify(data, null, 2))
         this.updateSolr(data.createTaxonConcept.id)
+        this.$nuxt.$emit('new-taxon-concept-created')
         this.$router.push({
           name: 'flora-taxon-edit',
           params: {

--- a/components/Forms/TaxonNameForm.vue
+++ b/components/Forms/TaxonNameForm.vue
@@ -210,6 +210,22 @@ export default {
       return schema
     }
   },
+  watch: {
+    parentName: {
+      immediate: true,
+      deep: true,
+      handler(parentName) {
+        if (this.formData.rank === undefined) {
+          const index = this.schema.map(element => element.name).indexOf('rank')
+          let options = this.schema[index].options
+          const optionIndex = options.map(option => option.value).indexOf(this.parentName.rank)
+          options.splice(0, optionIndex + 1)
+          this.schema[index].options = options
+          this.formData.rank = options[0].value
+        }
+      }
+    }
+  },
   created() {
     this.$nuxt.$on('taxon-name-form-input', (field, value) => {
       if (field === 'rank') {

--- a/components/Taxon/TaxonEditMenu.vue
+++ b/components/Taxon/TaxonEditMenu.vue
@@ -1,12 +1,12 @@
 <!--
  Copyright 2022 Royal Botanic Gardens Board
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
      http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,24 +16,30 @@
 
 <template>
   <div class="taxon-edit-menu text-right">
-    <b-button 
+    <b-button
       v-if="showView"
       variant="primary"
       size="sm"
       :to="{name: 'flora-taxon-id', params: { id: $route.params.id } }"
     ><FontAwesomeIcon icon="eye"/> View</b-button>
-    <b-button 
+    <b-button
       v-if="showEdit"
       variant="primary"
       size="sm"
       :to="{name: 'flora-taxon-edit', params: { id: $route.params.id } }"
     ><FontAwesomeIcon icon="pen-to-square"/> Edit</b-button>
-    <b-button 
+    <b-button
       v-if="showAddChild"
       variant="primary"
       size="sm"
       :to="{name: 'flora-taxon-add-child', params: { id: $route.params.id } }"
     ><FontAwesomeIcon icon="child"/> Add child</b-button>
+    <b-button
+      v-if="showRefetchData"
+      variant="primary"
+      size="sm"
+      @click="$nuxt.$emit('refetch-data-button-clicked')"
+    ><FontAwesomeIcon icon="rotate"/> Refetch data</b-button>
   </div>
 </template>
 
@@ -46,6 +52,7 @@ export default {
       showView: false,
       showEdit: false,
       showAddChild: false,
+      showRefetchData: false,
     }
   },
   created() {
@@ -53,8 +60,9 @@ export default {
       case 'flora-taxon-id':
         this.showEdit = true
         this.showAddChild = true
+        this.showRefetchData = true
         break;
-    
+
       case 'flora-taxon-edit':
         this.showView = true
         break;
@@ -62,7 +70,7 @@ export default {
       case 'flora-taxon-add-child':
         this.showView = true
         break;
-    
+
       default:
         break;
     }

--- a/graphql/mutations/UpdateSolrIndexMutation.gql
+++ b/graphql/mutations/UpdateSolrIndexMutation.gql
@@ -1,0 +1,5 @@
+mutation UpdateSolrIndexMutation($id: ID!) {
+	updateSolrIndex(id: $id) {
+    id
+  }
+}

--- a/pages/flora/taxon/_id.vue
+++ b/pages/flora/taxon/_id.vue
@@ -114,18 +114,16 @@ export default {
       skip: true
     }
   },
-  beforeRouteEnter(to, from, next) {
-    next(vm => {
-      if (from && from.name === 'flora-taxon-edit') {
-        vm.$apollo.queries.taxonConcept.refetch()
-      }
-    })
-  },
   created() {
     this.$nuxt.$emit('progress-bar-start')
     this.$apollo.queries.taxonConcept.setVariables({id: this.$route.params.id})
     this.$apollo.queries.taxonConcept.skip = false
     this.lastSearch = this.$store.state.lastSearch
+
+    this.$nuxt.$on('refetch-data-button-clicked', () => {
+      console.log('Refetching data...')
+      this.$apollo.queries.taxonConcept.refetch()
+    })
   },
 }
 </script>

--- a/pages/flora/taxon/edit.vue
+++ b/pages/flora/taxon/edit.vue
@@ -50,13 +50,6 @@ const TaxonEditMenu = () => import('@/components/Taxon/TaxonEditMenu')
 const TaxonName = () => import('@/components/Taxon/TaxonName')
 const TaxonTabsEdit = () => import('@/components/Taxon/TaxonTabsEdit.vue')
 
-
-const updateSolrIndexMutation = gql`mutation UpdateSolrIndexMutation($id: ID!) {
-	updateSolrIndex(id: $id) {
-    id
-  }
-}`
-
 export default {
   name: "EditTaxon",
   components: {
@@ -101,18 +94,6 @@ export default {
 
     this.$nuxt.$on('taxon-reference-added', () => {
       this.$apollo.queries.taxonConcept.refetch()
-    })
-  },
-  beforeDestroy() {
-    this.$apollo.mutate({
-      mutation: updateSolrIndexMutation,
-      variables: {
-        id: this.$route.params.id,
-      },
-    }).then(({data}) => {
-      console.log('SOLR index updated: ' + data.updateSolrIndex.id)
-    }).catch(error => {
-      console.log(error)
     })
   },
 }


### PR DESCRIPTION
Made the following imporvements to the editor:

- moved the updateSolrIndex mutation from the beforeDestroy hook of the edit page to when the updateTaxonConcept or createTaxonConcept mutations have been successful
- set the available options and initial value of the rank dropdown in the Taxon Name form, based on the rank of the parent
- added a 'Refetch data' button to the edit menu on the taxon page, so that the children dropdown and the classification tab can be updated when going back to the parent page after a new child has been added. Could not get it to refetch the data automatically automatically.